### PR TITLE
JS-Error in Backend when in nested NodeTypes > row > column -> click on InlineEdit «create New»

### DIFF
--- a/Configuration/NodeTypes.yaml
+++ b/Configuration/NodeTypes.yaml
@@ -35,6 +35,8 @@
 'Sfi.Grid:Column':
   superTypes:
     'TYPO3.Neos:Content': true
+    'TYPO3.Neos:ContentCollection': true
+    
   ui:
     label: 'Grid - Column'
     group: structure

--- a/Configuration/NodeTypes.yaml
+++ b/Configuration/NodeTypes.yaml
@@ -36,7 +36,6 @@
   superTypes:
     'TYPO3.Neos:Content': true
     'TYPO3.Neos:ContentCollection': true
-    
   ui:
     label: 'Grid - Column'
     group: structure

--- a/Configuration/NodeTypes.yaml
+++ b/Configuration/NodeTypes.yaml
@@ -9,6 +9,7 @@
 'Sfi.Grid:Row':
   superTypes:
     'TYPO3.Neos:Content': true
+    'TYPO3.Neos:ContentCollection': true
   ui:
     label: 'Grid - Row'
     group: structure


### PR DESCRIPTION
Hi,
If I try to «Create new» in Neos Backend in a Column there will no «Create new panel» appear.
On the structure «Create new» -> No Problem.
In the Inline-Edit «Create new» -> NO PANEL

I try to figure out why. With help from discuss.neos.io Forum (https://discuss.neos.io/t/foundation-f6-grid-system-in-neos/1018/4) we found the problem:
Your Row and Column NodeTypes should intherit from TYPO3.Neos:ContentCollection. Than the Error don't appear and the «Create new Panel» will appear, no matter of click in structure panel or Inline-Edit.
